### PR TITLE
Fix MapContainer Controls

### DIFF
--- a/GentrysQuest.Game.Tests/Utils/MapContainer.cs
+++ b/GentrysQuest.Game.Tests/Utils/MapContainer.cs
@@ -54,10 +54,12 @@ namespace GentrysQuest.Game.Tests.Utils
 
                 case Key.Down:
                     mapScene.GetMap().Scale *= 0.5f;
+                    mapScene.GetMap().Position *= 0.5f;
                     break;
 
                 case Key.Up:
-                    mapScene.GetMap().Scale *= 1.5f;
+                    mapScene.GetMap().Scale *= 2f;
+                    mapScene.GetMap().Position *= 2f;
                     break;
             }
 


### PR DESCRIPTION
The map container did not follow the zoom pattern so it was hard to track. I've fixed this by moving the position with the same difference as the zoom.

ex:
```cs
// down
mapScene.GetMap().Scale *= 0.5f;
mapScene.GetMap().Position *= 0.5f;

// up
mapScene.GetMap().Scale *= 2f;
mapScene.GetMap().Position *= 2f;
```