### PR TITLE
Fix default map barriers not applying to all sides

### DIFF
--- a/GentrysQuest.Game.Tests/Utils/MapContainer.cs
+++ b/GentrysQuest.Game.Tests/Utils/MapContainer.cs
@@ -25,12 +25,7 @@ namespace GentrysQuest.Game.Tests.Utils
         }
 
         [BackgroundDependencyLoader]
-        private void load()
-        {
-            RelativeSizeAxes = Axes.Both;
-            Anchor = Anchor.Centre;
-            Origin = Anchor.Centre;
-        }
+        private void load() => RelativeSizeAxes = Axes.Both;
 
         protected override bool OnKeyDown(KeyDownEvent e)
         {

--- a/GentrysQuest.Game.Tests/Visual/Utils/MapViewer.cs
+++ b/GentrysQuest.Game.Tests/Visual/Utils/MapViewer.cs
@@ -3,12 +3,11 @@ using GentrysQuest.Game.Location;
 using GentrysQuest.Game.Tests.Utils;
 using NUnit.Framework;
 using osu.Framework.Graphics;
-using osu.Framework.Testing;
 
 namespace GentrysQuest.Game.Tests.Visual.Utils
 {
     [TestFixture]
-    public partial class MapViewer : TestScene
+    public partial class MapViewer : GentrysQuestTestScene
     {
         private readonly MapScene mapScene;
         private readonly MapContainer mapContainer;

--- a/GentrysQuest.Game.Tests/Visual/Utils/TestSceneFight.cs
+++ b/GentrysQuest.Game.Tests/Visual/Utils/TestSceneFight.cs
@@ -8,7 +8,6 @@ using GentrysQuest.Game.Location;
 using GentrysQuest.Game.Screens.Gameplay;
 using NUnit.Framework;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osuTK;
 
@@ -24,11 +23,6 @@ namespace GentrysQuest.Game.Tests.Visual.Utils
 
         public TestSceneFight()
         {
-            Add(new Box
-            {
-                RelativeSizeAxes = Axes.Both,
-                Colour = Colour4.Gray
-            });
             player = new DrawablePlayableEntity(new GMoney()) { Depth = -1 };
             player.GetBase().SetWeapon(new Sword());
             player.SetupClickContainer();

--- a/GentrysQuest.Game/Content/Maps/Jvee.cs
+++ b/GentrysQuest.Game/Content/Maps/Jvee.cs
@@ -28,14 +28,12 @@ namespace GentrysQuest.Game.Content.Maps
                     MathBase.GetFeetToPixels(540),
                     MathBase.GetFeetToPixels(530)
                 );
-            SpawnPoint = new Vector2(0, MathBase.GetFeetToPixels(-500));
+            // SpawnPoint = GetCoordinatePercent(0.5f, 0.9f);
         }
 
         public override void Load()
         {
             base.Load();
-
-            Objects.Add(new MapObject{Name="test", Position = new Vector2(100, 100), Size = new Vector2(100, 100)});
 
             #region ParkingLot
 
@@ -43,8 +41,7 @@ namespace GentrysQuest.Game.Content.Maps
             {
                 Name = "Concrete",
                 Colour = Colour4.Gray,
-                RelativeSizeAxes = Axes.Both,
-                Anchor = Anchor.Centre
+                RelativeSizeAxes = Axes.Both
             });
 
             Objects.Add(new MapObject

--- a/GentrysQuest.Game/Content/Maps/Jvee.cs
+++ b/GentrysQuest.Game/Content/Maps/Jvee.cs
@@ -25,17 +25,27 @@ namespace GentrysQuest.Game.Content.Maps
             Name = "J-Vee";
             Size = new
                 Vector2(
-                    MathBase.GetFeetToPixels(5),
-                    MathBase.GetFeetToPixels(5)
+                    MathBase.GetFeetToPixels(540),
+                    MathBase.GetFeetToPixels(530)
                 );
-            SpawnPoint = new Vector2(Size.X * 0.5f, -Size.Y + 10);
+            SpawnPoint = new Vector2(0, MathBase.GetFeetToPixels(-500));
         }
 
         public override void Load()
         {
             base.Load();
 
+            Objects.Add(new MapObject{Name="test", Position = new Vector2(100, 100), Size = new Vector2(100, 100)});
+
             #region ParkingLot
+
+            Objects.Add(new MapObject
+            {
+                Name = "Concrete",
+                Colour = Colour4.Gray,
+                RelativeSizeAxes = Axes.Both,
+                Anchor = Anchor.Centre
+            });
 
             Objects.Add(new MapObject
             {

--- a/GentrysQuest.Game/Graphics/GqBackground.cs
+++ b/GentrysQuest.Game/Graphics/GqBackground.cs
@@ -1,15 +1,29 @@
+using GentrysQuest.Game.Graphics.TextStyles;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 
 namespace GentrysQuest.Game.Graphics
 {
-    public partial class GqBackground : Box
+    public partial class GqBackground : CompositeDrawable
     {
-        public GqBackground()
+        public GqBackground() => Depth = 1;
+
+        [BackgroundDependencyLoader]
+        private void load()
         {
             RelativeSizeAxes = Axes.Both;
-            Colour = Colour4.Gray;
-            Depth = 1;
+            InternalChildren =
+            [
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = ColourInfo.GradientVertical(Colour4.LightGray, Colour4.DarkGray)
+                },
+                new TitleText("Gentry's Quest Test") { Origin = Anchor.TopCentre, Anchor = Anchor.TopCentre }
+            ];
         }
     }
 }

--- a/GentrysQuest.Game/Location/Drawables/DrawableMap.cs
+++ b/GentrysQuest.Game/Location/Drawables/DrawableMap.cs
@@ -3,6 +3,7 @@ using GentrysQuest.Game.Entity;
 using GentrysQuest.Game.Entity.Drawables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osuTK;
 
 namespace GentrysQuest.Game.Location.Drawables
 {
@@ -44,6 +45,18 @@ namespace GentrysQuest.Game.Location.Drawables
                 Npcs.Add(entity);
                 AddInternal(entity);
             }
+
+#if DEBUG
+            AddInternal(new MapObject
+            {
+                Name = "Spawn Point",
+                Position = map.SpawnPoint,
+                Size = new Vector2(150),
+                Alpha = 0.5f,
+                Colour = Colour4.LightBlue,
+                Origin = Anchor.Centre,
+            });
+#endif
         }
 
         public void Unload()

--- a/GentrysQuest.Game/Location/Map.cs
+++ b/GentrysQuest.Game/Location/Map.cs
@@ -15,6 +15,9 @@ namespace GentrysQuest.Game.Location
         public Vector2 Size { get; protected set; } = Vector2.Zero;
         public Vector2 SpawnPoint { get; protected set; } = Vector2.Zero;
 
+        /// <summary>
+        /// Loads map objects.
+        /// </summary>
         public virtual void Load()
         {
             // implement map loading logic
@@ -22,11 +25,28 @@ namespace GentrysQuest.Game.Location
             // Add barriers and floor
             // This is the default logic to prevent players from escaping,
             // But you do you
-            Objects.Add(new MapObject { RelativeSizeAxes = Axes.Both, Colour = Colour4.LightGray });
-            Objects.Add(new MapObject { HasCollider = true, Size = new Vector2(Size.X * 2, 10), Position = new Vector2(-Size.X, Size.Y), Colour = Colour4.Black });
-            Objects.Add(new MapObject { HasCollider = true, Size = new Vector2(Size.X * 2, 10), Position = new Vector2(-Size.X, -Size.Y), Colour = Colour4.Black });
-            Objects.Add(new MapObject { HasCollider = true, Size = new Vector2(10, Size.Y * 2), Position = new Vector2(Size.X, -Size.Y), Colour = Colour4.Black });
-            Objects.Add(new MapObject { HasCollider = true, Size = new Vector2(10, Size.Y * 2), Position = new Vector2(-Size.X, -Size.Y), Colour = Colour4.Black });
+
+            Objects.Add(new MapObject{ Name = "test", Position = new Vector2(2232,224)});
+
+            // top
+            Objects.Add(new MapObject
+            {
+                RelativeSizeAxes = Axes.X,
+                Size = new Vector2(1, 1),
+                HasCollider = true,
+                Filled = false
+            });
+
+            // bottom
+            Objects.Add(new MapObject
+            {
+                RelativeSizeAxes = Axes.X,
+                Size = new Vector2(1, 1),
+                RelativePositionAxes = Axes.Y,
+                Y = 1,
+                HasCollider = true,
+                Filled = false
+            });
         }
 
         public int Difficulty { get; protected set; } = 0;

--- a/GentrysQuest.Game/Location/Map.cs
+++ b/GentrysQuest.Game/Location/Map.cs
@@ -26,8 +26,6 @@ namespace GentrysQuest.Game.Location
             // This is the default logic to prevent players from escaping,
             // But you do you
 
-            Objects.Add(new MapObject{ Name = "test", Position = new Vector2(2232,224)});
-
             // top
             Objects.Add(new MapObject
             {
@@ -42,8 +40,28 @@ namespace GentrysQuest.Game.Location
             {
                 RelativeSizeAxes = Axes.X,
                 Size = new Vector2(1, 1),
-                RelativePositionAxes = Axes.Y,
-                Y = 1,
+                Anchor = Anchor.BottomLeft,
+                HasCollider = true,
+                Filled = false
+            });
+
+            // left
+            Objects.Add(new MapObject
+            {
+                RelativeSizeAxes = Axes.Y,
+                Size = new Vector2(1, 1),
+                Anchor = Anchor.TopLeft,
+                HasCollider = true,
+                Filled = false
+            });
+
+            // right
+            // left
+            Objects.Add(new MapObject
+            {
+                RelativeSizeAxes = Axes.Y,
+                Size = new Vector2(1, 1),
+                Anchor = Anchor.TopRight,
                 HasCollider = true,
                 Filled = false
             });
@@ -51,6 +69,14 @@ namespace GentrysQuest.Game.Location
 
         public int Difficulty { get; protected set; } = 0;
         public bool DifficultyScales { get; protected set; } = false;
+
+        /// <summary>
+        /// Get coordinates based off percentage.
+        /// </summary>
+        /// <param name="x">X percentage</param>
+        /// <param name="y">Y percentage</param>
+        /// <returns>Vector2 coordinates</returns>
+        public Vector2 GetCoordinatePercent(float x, float y) => new(x * (Size.X * 2), y * (Size.Y * 2));
 
         /// <summary>
         /// Code that runs every frame

--- a/GentrysQuest.Game/Location/MapObject.cs
+++ b/GentrysQuest.Game/Location/MapObject.cs
@@ -11,14 +11,13 @@ namespace GentrysQuest.Game.Location;
 
 public partial class MapObject : CompositeDrawable
 {
-    public bool HasCollider { get; set; } = false;
+    public bool HasCollider { get; set; }
     public override Vector2 Size { get; set; } = Vector2.One;
     public EventHandler OnTouchEvent { get; set; } = null;
     public new Anchor Anchor { get; set; } = Anchor.Centre;
     public override Anchor Origin { get; set; } = Anchor.TopLeft;
     public override Axes RelativeSizeAxes { get; set; } = Axes.None;
     public new Axes RelativePositionAxes { get; set; } = Axes.None;
-    public new Vector2 Position { get; set; } = Vector2.Zero;
     public int Health { get; set; } = 10000;
     public int Hardness { get; set; } = 1;
     public bool Filled { get; set; } = true;

--- a/GentrysQuest.Game/Location/MapObject.cs
+++ b/GentrysQuest.Game/Location/MapObject.cs
@@ -14,10 +14,6 @@ public partial class MapObject : CompositeDrawable
     public bool HasCollider { get; set; }
     public override Vector2 Size { get; set; } = Vector2.One;
     public EventHandler OnTouchEvent { get; set; } = null;
-    public new Anchor Anchor { get; set; } = Anchor.Centre;
-    public override Anchor Origin { get; set; } = Anchor.TopLeft;
-    public override Axes RelativeSizeAxes { get; set; } = Axes.None;
-    public new Axes RelativePositionAxes { get; set; } = Axes.None;
     public int Health { get; set; } = 10000;
     public int Hardness { get; set; } = 1;
     public bool Filled { get; set; } = true;


### PR DESCRIPTION
The map barriers would only show up on the top and left sides. After digging into it, I discovered that there were some issues with position properties in the `MapObject`'s `Position` property. Instead will use `X` and `Y` properties.