### PR TITLE
add `TextureMapping` to TestArtifact

### DIFF
--- a/GentrysQuest.Game/Content/Families/TestFamily.cs
+++ b/GentrysQuest.Game/Content/Families/TestFamily.cs
@@ -1,4 +1,5 @@
 using GentrysQuest.Game.Entity;
+using GentrysQuest.Game.Graphics;
 
 namespace GentrysQuest.Game.Content.Families
 {
@@ -18,6 +19,7 @@ namespace GentrysQuest.Game.Content.Families
             : base()
         {
             Name = "Test Artifact";
+            TextureMapping = new TextureMapping();
         }
 
         public override Family family { get; protected set; } = new TestFamily();


### PR DESCRIPTION
After adding a DrawableTextureMapping, the TextureMapping wasn't needed, so it doesn't get initialized on its own.