### PR TITLE
Improved stat calculations

### DIFF
--- a/GentrysQuest.Game/Content/Characters/Airxy.cs
+++ b/GentrysQuest.Game/Content/Characters/Airxy.cs
@@ -1,7 +1,6 @@
+using System;
 using GentrysQuest.Game.Content.Skills;
 using GentrysQuest.Game.Entity;
-using osu.Framework.Bindables;
-using System;
 
 namespace GentrysQuest.Game.Content.Characters
 {
@@ -20,13 +19,12 @@ namespace GentrysQuest.Game.Content.Characters
 
             Secondary = new CursedSpeech();
 
-            Stats.Health.Minimum = new Bindable<double>(5);
-            Stats.Health.SetDefaultValue(1);
+            Stats.Health.SetDefaultValue(32432);
 
             Stats.Attack.Point = 4;
-            Stats.Attack.Minimum = new Bindable<double>(50);
+            Stats.Attack.SetDefaultValue(50);
 
-            Stats.Defense = new AirxyDefense("Defense", StatType.Defense, 0);
+            Stats.Defense = new AirxyDefense("Defense", StatType.Defense);
 
             OnGetHit += details =>
             {
@@ -49,13 +47,13 @@ namespace GentrysQuest.Game.Content.Characters
 
             RebuildStatAdditionalValues();
 
-            Stats.Health.SetDefaultValue(5 * Difficulty);
+            Stats.Health.SetDefaultValue(5 + (5 * Difficulty));
             Stats.Health.Current.Value = Math.Clamp(Stats.Health.Total() - missingHealth, 0, Stats.Health.Total());
         }
     }
 
-    public class AirxyDefense(string name, StatType statType, double minimumValue)
-        : Stat(name, statType, minimumValue)
+    public class AirxyDefense(string name, StatType statType)
+        : Stat(name, statType)
     {
         public override double GetDefault() => 0;
         public override double GetAdditional() => 0;

--- a/GentrysQuest.Game/Content/Enemies/LostSpirit.cs
+++ b/GentrysQuest.Game/Content/Enemies/LostSpirit.cs
@@ -31,9 +31,7 @@ namespace GentrysQuest.Game.Content.Enemies
         {
             base.UpdateStats();
             Stats.Health.SetDefaultValue(100);
-            Stats.Health.Minimum.Value = 100;
             Stats.Speed.SetDefaultValue(0.25);
-            Stats.Speed.Minimum.Value = 0.25;
         }
     }
 }

--- a/GentrysQuest.Game/Entity/Drawables/DrawableEntity.cs
+++ b/GentrysQuest.Game/Entity/Drawables/DrawableEntity.cs
@@ -266,7 +266,7 @@ namespace GentrysQuest.Game.Entity.Drawables
         /// Manages the speed of the entity
         /// </summary>
         /// <returns></returns>
-        public double GetSpeed() => (SPEED_MAIN * Entity.Stats.Speed.Current.Value * Entity.SpeedModifier) + Entity.PositionJump;
+        public double GetSpeed() => SPEED_MAIN * Entity.Stats.Speed.GetCurrent() * Entity.SpeedModifier + Entity.PositionJump;
 
         public void AddParticle(Particle particle) => Particles.Add(particle);
 

--- a/GentrysQuest.Game/Entity/Enemy.cs
+++ b/GentrysQuest.Game/Entity/Enemy.cs
@@ -27,22 +27,15 @@ public class Enemy : Entity
         damage += (int)(10 * Difficulty * level);
         Stats.Attack.SetDefaultValue(damage);
 
-        Stats.Defense.SetDefaultValue(
-            CalculatePointBenefit(Difficulty * 30, Stats.Defense.Point, 18) +
-            CalculatePointBenefit(level * 1, Stats.Defense.Point, 2)
-        );
+        Stats.Defense.SetDefaultValue(100);
 
         Stats.CritRate.SetDefaultValue(20);
 
         Stats.CritDamage.SetDefaultValue(Difficulty * 20);
 
-        Stats.Speed.SetDefaultValue(
-            CalculatePointBenefit(0, Stats.Speed.Point, 0.2)
-        );
+        Stats.Speed.SetDefaultValue(0.75f);
 
-        Stats.AttackSpeed.SetDefaultValue(
-            CalculatePointBenefit(0, Stats.AttackSpeed.Point, 0.3)
-        );
+        Stats.AttackSpeed.SetDefaultValue(1);
 
         RemoveStatModifierSourcesByPrefix("equipment:");
 

--- a/GentrysQuest.Game/Entity/HealthStat.cs
+++ b/GentrysQuest.Game/Entity/HealthStat.cs
@@ -4,11 +4,9 @@ namespace GentrysQuest.Game.Entity
     {
         private double previousMaxHealth;
 
-        public HealthStat(double minimumValue)
-            : base("Health", StatType.Health, minimumValue)
-        {
+        public HealthStat()
+            : base("Health", StatType.Health) =>
             previousMaxHealth = Total();
-        }
 
         public override void Recalculate()
         {

--- a/GentrysQuest.Game/Entity/IntStat.cs
+++ b/GentrysQuest.Game/Entity/IntStat.cs
@@ -1,33 +1,20 @@
-// * Name              : GentrysQuest.Game
-//  * Author           : Brayden J Messerschmidt
-//  * Created          : 05/28/2024
-//  * Course           : CIS 169 C#
-//  * Version          : 1.0
-//  * OS               : Windows 11 22H2
-//  * IDE              : Jet Brains Rider 2023
-//  * Copyright        : This is my work.
-//  * Description      : desc.
-//  * Academic Honesty : I attest that this is my original work.
-//  * I have not used unauthorized source code, either modified or
-//  * unmodified. I have not given other fellow student(s) access
-//  * to my program.
-
-namespace GentrysQuest.Game.Entity;
-
-public class IntStat : Stat
+namespace GentrysQuest.Game.Entity
 {
-    public IntStat(string name, StatType statType, double minimumValue)
-        : base(name, statType, minimumValue)
+    public class IntStat : Stat
     {
-        // This is how it's meant to be! :)
-    }
+        public IntStat(string name, StatType statType)
+            : base(name, statType)
+        {
+            // This is how it's meant to be! :)
+        }
 
-    public override double GetDefault() => (int)base.GetDefault();
-    public override double GetAdditional() => (int)base.GetAdditional();
-    public override double GetCurrent() => (int)base.GetCurrent();
+        public override double GetDefault() => (int)base.GetDefault();
+        public override double GetAdditional() => (int)base.GetAdditional();
+        public override double GetCurrent() => (int)base.GetCurrent();
 
-    public override double Total()
-    {
-        return (int)base.Total();
+        public override double Total()
+        {
+            return (int)base.Total();
+        }
     }
 }

--- a/GentrysQuest.Game/Entity/Stat.cs
+++ b/GentrysQuest.Game/Entity/Stat.cs
@@ -21,18 +21,16 @@ namespace GentrysQuest.Game.Entity
         public bool IsPercent { get; private set; }
 
         public Bindable<double> Default { get; set; } = new();
-        public Bindable<double> Minimum { get; set; } = new();
         public Bindable<double> Current { get; set; } = new();
         public Bindable<double> Additional { get; set; } = new();
 
         private readonly Dictionary<string, Func<Stat, double, double>> totalModifiers = new();
         protected double LastTotal = 0;
 
-        public Stat(string name, StatType statType, double minimumValue)
+        public Stat(string name, StatType statType)
         {
             Name = name;
             StatType = statType;
-            Minimum.Value = minimumValue;
             Current.Value = Total();
 
             IsPercent = statType switch
@@ -61,7 +59,7 @@ namespace GentrysQuest.Game.Entity
 
         public virtual void SetDefaultValue(double value)
         {
-            Default.Value = ClampDefault(value);
+            Default.Value = value;
             Recalculate();
         }
 
@@ -96,8 +94,6 @@ namespace GentrysQuest.Game.Entity
         protected virtual double CalculateBaseTotal() => Default.Value + Additional.Value;
 
         protected virtual double TransformAdditional(double value) => value;
-
-        protected virtual double ClampDefault(double value) => value < Minimum.Value ? Minimum.Value : value;
 
         protected virtual double ClampCurrent(double value, double maxValue)
         {

--- a/GentrysQuest.Game/Entity/Stats.cs
+++ b/GentrysQuest.Game/Entity/Stats.cs
@@ -4,16 +4,16 @@
     /// Stat management class /// </summary>
     public class Stats
     {
-        public Stat Health = new HealthStat(100);
-        public Stat Attack = new IntStat("Attack", StatType.Attack, 10);
-        public Stat Defense = new IntStat("Defense", StatType.Defense, 100);
-        public Stat CritRate = new IntStat("CritRate", StatType.CritRate, 1);
-        public Stat CritDamage = new IntStat("CritDamage", StatType.CritDamage, 20);
-        public Stat Speed = new("Speed", StatType.Speed, 1);
-        public Stat AttackSpeed = new("AttackSpeed", StatType.AttackSpeed, 1);
-        public Stat RegenSpeed = new("RegenSpeed", StatType.RegenSpeed, 0);
-        public Stat RegenStrength = new IntStat("RegenStrength", StatType.RegenStrength, 1);
-        public Stat Tenacity = new IntStat("Tenacity", StatType.Tenacity, 3);
+        public Stat Health = new HealthStat();
+        public Stat Attack = new IntStat("Attack", StatType.Attack);
+        public Stat Defense = new IntStat("Defense", StatType.Defense);
+        public Stat CritRate = new IntStat("CritRate", StatType.CritRate);
+        public Stat CritDamage = new IntStat("CritDamage", StatType.CritDamage);
+        public Stat Speed = new("Speed", StatType.Speed);
+        public Stat AttackSpeed = new("AttackSpeed", StatType.AttackSpeed);
+        public Stat RegenSpeed = new("RegenSpeed", StatType.RegenSpeed);
+        public Stat RegenStrength = new IntStat("RegenStrength", StatType.RegenStrength);
+        public Stat Tenacity = new IntStat("Tenacity", StatType.Tenacity);
         private readonly Stat[] statGrouping;
 
         public Stats()

--- a/GentrysQuest.Game/Entity/Weapon.cs
+++ b/GentrysQuest.Game/Entity/Weapon.cs
@@ -30,7 +30,7 @@ namespace GentrysQuest.Game.Entity.Weapon
         /// A stat representing the damage.
         /// Makes more sense to have set in constructor
         /// </summary>
-        public Stat Damage = new("Damage", StatType.Attack, 0); // Base damage
+        public Stat Damage = new("Damage", StatType.Attack); // Base damage
 
         #endregion
 


### PR DESCRIPTION
Stats would sometimes be zero because `Current` wouldn't take into account the `Minimum` stat. Sometimes You would want stats to be zero, but if `Current` took into account `Minimum` all the time it would cause problems with this. I have removed `Minimum` and just used `Default` for it. With the current code, you can make a lot of cool things happen.